### PR TITLE
Fixed typo in composer path for Laravel providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "el-hendawy/laralestic",
+    "name": "ryanedgar/laralestic",
     "description": "Laravel, Lumen and Native php Elasticseach & Opensearch query builder to build complex queries using an elegant syntax ORM",
     "license": "MIT",
     "type": "package",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ryanedgar/laralestic",
+    "name": "el-hendawy/laralestic",
     "description": "Laravel, Lumen and Native php Elasticseach & Opensearch query builder to build complex queries using an elegant syntax ORM",
     "license": "MIT",
     "type": "package",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
             "src/helpers.php"
         ]
     },
-    "minimum-stability":"dev",
+    "minimum-stability": "dev",
     "autoload-dev": {
         "psr-4": {
             "Omar\\Laralestic\\Tests\\": "tests/"
@@ -50,12 +50,11 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Omar\\Laralectic\\LaralecticServiceProvider"
+                "Omar\\Laralestic\\LaralecticServiceProvider"
             ],
             "aliases": {
-                "ES": "Omar\\Laralectic\\Facades\\ES"
+                "ES": "Omar\\Laralestic\\Facades\\ES"
             }
         }
     }
-
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -104,6 +104,8 @@ class Connection
             // Instantiate a new ClientBuilder
             $clientBuilder = ClientBuilder::create();
 
+            $clientBuilder->setSSLVerification($config["verify_ssl"]);
+
             $clientBuilder->setHosts($config["servers"]);
 
             $clientBuilder = self::configureLogging($clientBuilder,$config);

--- a/src/LaralecticServiceProvider.php
+++ b/src/LaralecticServiceProvider.php
@@ -62,7 +62,10 @@ class LaralecticServiceProvider extends ServiceProvider
                     $config = config('es.connections.' . config('scout.es.connection'));
 
                     return new ScoutEngine(
-                        ElasticBuilder::create()->setHosts($config["servers"])->build(),
+                        ElasticBuilder::create()
+                            ->setHosts($config["servers"])
+                            ->setSSLVerification($config["verify_ssl"])
+                            ->build(),
                         $config["index"]
                     );
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -950,12 +950,12 @@ class Query
 
                 $model->setConnection($model->getConnection());
                 $model->setIndex($row["_index"]);
-                $model->setType($row["_type"]);
+                $model->setType($row["_type"] ?? NULL);
 
                 // match earlier version
 
                 $model->_index = $row["_index"];
-                $model->_type = $row["_type"];
+                $model->_type = $row["_type"] ?? NULL;
                 $model->_id = $row["_id"];
                 $model->_score = $row["_score"];
 

--- a/src/config/es.php
+++ b/src/config/es.php
@@ -40,6 +40,9 @@ return [
 
             ],
 
+            // Set false to skip certificate verification in local developer setup
+            'verify_ssl' => env('ELASTIC_VERIFY_SSL', true),
+
             'index' => env('ELASTIC_INDEX', 'my_index'),
 
             // Elasticsearch handlers


### PR DESCRIPTION
The typo in the path caused the auto-discovery in Laravel to fail.

```> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover

In ProviderRepository.php line 208:
                                                               
  Class "Omar\Laralectic\LaralecticServiceProvider" not found  
                                                               

Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```